### PR TITLE
Don't load all books and schools in specs

### DIFF
--- a/lib/openstax/salesforce/spec_helpers.rb
+++ b/lib/openstax/salesforce/spec_helpers.rb
@@ -185,13 +185,13 @@ module OpenStax::Salesforce::SpecHelpers
         config.define_cassette_placeholder('<salesforce_instance_url_lower>') do
           authentication.instance_url.downcase
         end
-        config.define_cassette_placeholder('<salesforce_id>' ) do
+        config.define_cassette_placeholder('<salesforce_id>') do
           authentication.id
         end
         config.define_cassette_placeholder('<salesforce_access_token>') do
           authentication.access_token
         end
-        config.define_cassette_placeholder('<salesforce_signature>' ) do
+        config.define_cassette_placeholder('<salesforce_signature>') do
           authentication.signature
         end
       end

--- a/lib/openstax/salesforce/spec_helpers.rb
+++ b/lib/openstax/salesforce/spec_helpers.rb
@@ -169,5 +169,32 @@ module OpenStax::Salesforce::SpecHelpers
     def school(name)
       schools.find { |ss| ss.name == name }
     end
+
+    def setup_cassette
+      VCR.configure do |config|
+        config.define_cassette_placeholder('<salesforce_instance_url>') do
+          'https://example.salesforce.com'
+        end
+        config.define_cassette_placeholder('<salesforce_instance_url_lower>') do
+          'https://example.salesforce.com'
+        end
+        authentication = ActiveForce.sfdc_client.authenticate!
+        config.define_cassette_placeholder('<salesforce_instance_url>') do
+          authentication.instance_url
+        end
+        config.define_cassette_placeholder('<salesforce_instance_url_lower>') do
+          authentication.instance_url.downcase
+        end
+        config.define_cassette_placeholder('<salesforce_id>' ) do
+          authentication.id
+        end
+        config.define_cassette_placeholder('<salesforce_access_token>') do
+          authentication.access_token
+        end
+        config.define_cassette_placeholder('<salesforce_signature>' ) do
+          authentication.signature
+        end
+      end
+    end
   end
 end

--- a/lib/openstax/salesforce/spec_helpers.rb
+++ b/lib/openstax/salesforce/spec_helpers.rb
@@ -131,27 +131,23 @@ module OpenStax::Salesforce::SpecHelpers
     end
 
     def ensure_books_exist(book_names)
-      book_names.each do |book_name|
-        if books.none? {|bb| bb.name == book_name}
-          book = Book.new(name: book_name)
-          book.save!
-          books.push(book)
-        end
+      @books = OpenStax::Salesforce::Remote::Book.where(name: book_names).to_a
+
+      (book_names - books.map(&:name)).each do |book_name|
+        OpenStax::Salesforce::Remote::Book.new(name: book_name).save!
       end
     end
 
     def ensure_schools_exist(school_names)
-      school_names.compact.each do |school_name|
-        if schools.none? {|ss| ss.name == school_name}
-          school = School.new(name: school_name)
-          school.save!
-          schools.push(school)
-        end
+      @schools = OpenStax::Salesforce::Remote::School.where(name: school_names).to_a
+
+      (school_names - schools.map(&:name)).each do |school_name|
+        OpenStax::Salesforce::Remote::School.new(name: school_name).save!
       end
     end
 
     def books
-      @books ||= Book.all
+      @books ||= OpenStax::Salesforce::Remote::Book.all
     end
 
     def book(name)
@@ -163,7 +159,7 @@ module OpenStax::Salesforce::SpecHelpers
     end
 
     def schools
-      @schools ||= School.all
+      @schools ||= OpenStax::Salesforce::Remote::School.all
     end
 
     def school_id(name)

--- a/lib/openstax/salesforce/version.rb
+++ b/lib/openstax/salesforce/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Salesforce
-    VERSION = '4.0.0'
+    VERSION = '4.0.1'
   end
 end


### PR DESCRIPTION
There are a lot of books and schools in the sandbox so we don't want to put them all in the cassettes.

Also adds a convenience method to remove sensitive data from the cassettes.