### PR TITLE
Improve validations to work with existing Accounts logic

### DIFF
--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -1,7 +1,13 @@
 module OpenStax::Salesforce::Remote
   class Lead < ActiveForce::SObject
 
-    VALID_VERIFICATION_STATUSES = %w[pending_faculty confirmed_faculty rejected_faculty].freeze
+    VALID_VERIFICATION_STATUSES = %w[
+      pending_faculty
+      confirmed_faculty
+      rejected_faculty
+      no_faculty_info
+    ].freeze
+
     VALID_ROLES = %w[
       student
       instructor
@@ -13,6 +19,7 @@ module OpenStax::Salesforce::Remote
       instructional\ designer
       home\ school\ teacher
     ].freeze
+
     VALID_WHO_CHOOSES_BOOKS = %w[instructor committee coordinator].freeze
 
     field :name,                from: "Name"

--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -4,6 +4,7 @@ module OpenStax::Salesforce::Remote
     VALID_VERIFICATION_STATUSES = %w[pending_faculty confirmed_faculty rejected_faculty].freeze
     VALID_ROLES = %w[
       student
+      instructor
       faculty
       other
       administrator
@@ -37,15 +38,8 @@ module OpenStax::Salesforce::Remote
     field :verification_status, from: "FV_Status__c"
     field :finalize_educator_signup,   from: "FV_Final__c", as: :boolean
 
-    validates(
-      :role,
-      allow_blank: true,
-      inclusion: {
-        in: VALID_ROLES,
-        message: "must be either #{VALID_ROLES.join(' or ')}"
-      }
-    )
-
+    validates(:last_name, presence: true)
+    validates(:school, presence: true)
     validates(
       :verification_status,
       allow_blank: true,

--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -45,6 +45,15 @@ module OpenStax::Salesforce::Remote
     field :verification_status, from: "FV_Status__c"
     field :finalize_educator_signup,   from: "FV_Final__c", as: :boolean
 
+    validates(
+      :role,
+      allow_blank: true,
+      inclusion: {
+        in: VALID_ROLES,
+        message: "must be either #{VALID_ROLES.join(' or ')}"
+      }
+    )
+
     validates(:last_name, presence: true)
     validates(:school, presence: true)
     validates(


### PR DESCRIPTION
school and last_name are also required fields. 

Additionally, instructor as the role seems to work somehow in salesforce — which is good because all Accounts logic uses "instructor" as the role not "faculty".