### PR TITLE
Remove role validation

### DIFF
--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -8,18 +8,6 @@ module OpenStax::Salesforce::Remote
       no_faculty_info
     ].freeze
 
-    VALID_ROLES = %w[
-      student
-      instructor
-      faculty
-      other
-      administrator
-      librarian
-      adjunct\ faculty
-      instructional\ designer
-      home\ school\ teacher
-    ].freeze
-
     VALID_WHO_CHOOSES_BOOKS = %w[instructor committee coordinator].freeze
 
     field :name,                from: "Name"
@@ -44,15 +32,6 @@ module OpenStax::Salesforce::Remote
     field :who_chooses_books,   from: "who_chooses_books__c"
     field :verification_status, from: "FV_Status__c"
     field :finalize_educator_signup,   from: "FV_Final__c", as: :boolean
-
-    validates(
-      :role,
-      allow_blank: true,
-      inclusion: {
-        in: VALID_ROLES,
-        message: "must be either #{VALID_ROLES.join(' or ')}"
-      }
-    )
 
     validates(:last_name, presence: true)
     validates(:school, presence: true)


### PR DESCRIPTION
Causes a problem in Accounts when users' role is Other, they can enter it in Accounts but because of this validation, Salesforce never gets it.