### PR TITLE
Add title_1_school field to Leads and Contacts

### DIFF
--- a/lib/openstax/salesforce/remote/contact.rb
+++ b/lib/openstax/salesforce/remote/contact.rb
@@ -19,6 +19,7 @@ module OpenStax::Salesforce::Remote
     field :adoption_status,              from: "Adoption_Status__c"
     field :grant_tutor_access,           from: "Grant_Tutor_Access__c", as: :boolean
     field :b_r_i_marketing,              from: "BRI_Marketing__c", as: :boolean # Bill of Rights Institute (book) marketing
+    field :title_1_school,               from: "Title_1_school__c", as: :boolean
 
     self.table_name = 'Contact'
   end

--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -34,6 +34,7 @@ module OpenStax::Salesforce::Remote
     field :verification_status, from: "FV_Status__c"
     field :finalize_educator_signup,   from: "FV_Final__c", as: :boolean
     field :needs_cs_review,   from: "Needs_CS_Review__c", as: :boolean
+    field :title_1_school,    from: "Title_1_school__c", as: :boolean
 
     validates(:last_name, presence: true)
     validates(:school, presence: true)

--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -34,6 +34,7 @@ module OpenStax::Salesforce::Remote
     field :verification_status, from: "FV_Status__c"
     field :finalize_educator_signup,   from: "FV_Final__c", as: :boolean
     field :needs_cs_review,   from: "Needs_CS_Review__c", as: :boolean
+    field :b_r_i_marketing,   from: "BRI_Marketing__c", as: :boolean # Bill of Rights Institute (book) marketing
     field :title_1_school,    from: "Title_1_school__c", as: :boolean
 
     validates(:last_name, presence: true)


### PR DESCRIPTION
Add title_1_school field to Leads + Contacts

Also adds back the `b_r_i_marketing` field to Leads because it turns out it's also needed there as well as in Contacts.