### PR TITLE
Remove unused fields on contact

### DIFF
--- a/lib/openstax/salesforce/remote/contact.rb
+++ b/lib/openstax/salesforce/remote/contact.rb
@@ -21,7 +21,6 @@ module OpenStax
         field :school_type,                  from: 'School_Type__c'
         field :send_faculty_verification_to, from: 'SendFacultyVerificationTo__c'
         field :all_emails,                   from: 'All_Emails__c'
-        field :confirmed_emails,             from: 'Confirmed_Emails__c'
         field :adoption_status,              from: 'Adoption_Status__c'
         field :grant_tutor_access,           from: 'Grant_Tutor_Access__c', as: :boolean
         field :b_r_i_marketing,              from: 'BRI_Marketing__c', as: :boolean # Bill of Rights Institute (book) marketing

--- a/lib/openstax/salesforce/remote/contact.rb
+++ b/lib/openstax/salesforce/remote/contact.rb
@@ -23,7 +23,6 @@ module OpenStax
         field :all_emails,                   from: 'All_Emails__c'
         field :adoption_status,              from: 'Adoption_Status__c'
         field :grant_tutor_access,           from: 'Grant_Tutor_Access__c', as: :boolean
-        field :b_r_i_marketing,              from: 'BRI_Marketing__c', as: :boolean # Bill of Rights Institute (book) marketing
         field :title_1_school,               from: 'Title_1_school__c', as: :boolean
         field :accounts_uuid,                from: 'Accounts_UUID__c'
         field :lead_source,                  from: 'LeadSource'

--- a/lib/openstax/salesforce/version.rb
+++ b/lib/openstax/salesforce/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Salesforce
-    VERSION = '7.5.1'
+    VERSION = '7.6.0'
   end
 end

--- a/openstax_salesforce.gemspec
+++ b/openstax_salesforce.gemspec
@@ -7,8 +7,8 @@ require "openstax/salesforce/version"
 Gem::Specification.new do |s|
   s.name        = "openstax_salesforce"
   s.version     = OpenStax::Salesforce::VERSION
-  s.authors     = ["JP Slavinsky", "Dante Soares", "Michael Harrison"]
-  s.email       = ["mwharrison@rice.edu"]
+  s.authors     = ["JP Slavinsky", "Dante Soares", "Michael Volo"]
+  s.email       = ["volo@rice.edu"]
   s.homepage    = "https://github.com/openstax/openstax_salesforce"
   s.summary     = "Interface gem for accessing OpenStax's Salesforce instance"
   s.description = "Interface gem for accessing OpenStax's Salesforce instance"


### PR DESCRIPTION
This was causing a bug in the admin of accounts (for sure, maybe more places) because these fields no longer exist on the contact in Salesforce.