### PR TITLE
pull districts on school objects

### DIFF
--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -40,11 +40,12 @@ module OpenStax
         field :sheerid_school_name, from: 'SheerID_School_Name__c'
         field :instant_conversion,  from: 'Instant_Conversion__c', as: :boolean
         field :signup_date,         from: 'Signup_Date__c', as: :datetime
+        field :self_reported_school, from: 'Self_Reported_School__c'
 
         # These 2 fields both hold the Account (School) ID, but have different data types and uses in SF
         field :account_id,          from: 'Account_ID__c'
         field :school_id,           from: 'School__c'
-        
+
         self.table_name = 'Lead'
 
       end

--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -44,10 +44,7 @@ module OpenStax
         # These 2 fields both hold the Account (School) ID, but have different data types and uses in SF
         field :account_id,          from: 'Account_ID__c'
         field :school_id,           from: 'School__c'
-
-        validates(:last_name, presence: true)
-        validates(:school, presence: true)
-
+        
         self.table_name = 'Lead'
 
       end

--- a/lib/openstax/salesforce/remote/school.rb
+++ b/lib/openstax/salesforce/remote/school.rb
@@ -20,7 +20,7 @@ module OpenStax
         self.table_name = 'Account'
 
         def self.query
-          super.where("RecordType.Name = 'School'")
+          super.where("RecordType.Name = 'School' OR RecordType.Name = 'School District'")
         end
       end
     end

--- a/lib/openstax/salesforce/version.rb
+++ b/lib/openstax/salesforce/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Salesforce
-    VERSION = '7.6.0'
+    VERSION = '7.6.1'
   end
 end

--- a/spec/factories/contact.rb
+++ b/spec/factories/contact.rb
@@ -19,7 +19,6 @@ FactoryBot.define do
     end
     send_faculty_verification_to { Faker::Internet.safe_email }
     all_emails { Faker::Internet.safe_email }
-    confirmed_emails { Faker::Internet.safe_email }
     adoption_status { ['Confirmed Adoption Won', 'Confirmed Adoption Recommend', 'High Interest In Using', 'Not Using'].sample }
     grant_tutor_access { Faker::Boolean.boolean }
     accounts_uuid { Faker::Internet.uuid }


### PR DESCRIPTION
We have users getting assigned School Districts in accounts, so we need to store those too.
Also, added a new field to store self reported school info for a user, for when the school is not found in the accounts db.

This also fixes a spec with the previous PR contact change.