### PR TITLE
Pull in General record types for Account/School

### DIFF
--- a/lib/openstax/salesforce/remote/school.rb
+++ b/lib/openstax/salesforce/remote/school.rb
@@ -20,7 +20,7 @@ module OpenStax
         self.table_name = 'Account'
 
         def self.query
-          super.where("RecordType.Name = 'School' OR RecordType.Name = 'School District'")
+          super.where("RecordType.Name = 'School' OR RecordType.Name = 'School District' OR RecordType.Name = 'General'")
         end
       end
     end

--- a/lib/openstax/salesforce/version.rb
+++ b/lib/openstax/salesforce/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Salesforce
-    VERSION = '7.6.1'
+    VERSION = '7.6.2'
   end
 end


### PR DESCRIPTION
A lot of users in accounts are associated with a "School" that is more of an afterschool program or other non-school type institution. This is causing sync errors in accounts, pulling these in will assist in matching schools with users during contact syncs.