### PR TITLE
add tracking params to the lead object

### DIFF
--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -41,6 +41,7 @@ module OpenStax
         field :instant_conversion,  from: 'Instant_Conversion__c', as: :boolean
         field :signup_date,         from: 'Signup_Date__c', as: :datetime
         field :self_reported_school, from: 'Self_Reported_School__c'
+        field :tracking_parameters,  from: 'Tracking_Parameters__c'
 
         # These 2 fields both hold the Account (School) ID, but have different data types and uses in SF
         field :account_id,          from: 'Account_ID__c'

--- a/lib/openstax/salesforce/version.rb
+++ b/lib/openstax/salesforce/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Salesforce
-    VERSION = '7.8.0'
+    VERSION = '7.8.1'
   end
 end


### PR DESCRIPTION
We use this field to track where adoptions are being reported from. Until now, we had a 'guessing system' for accounts. To make sure we have quality data, we will set this during lead creation.