### PR TITLE
add field to see if school has assignable integration

### DIFF
--- a/lib/openstax/salesforce/remote/school.rb
+++ b/lib/openstax/salesforce/remote/school.rb
@@ -16,6 +16,7 @@ module OpenStax
         field :is_kip,                  from: 'K_I_P__c',        as: :boolean
         field :is_child_of_kip,         from: 'child_of_kip__c', as: :boolean
         field :total_school_enrollment, from: 'Total_School_Enrollment__c', as: :integer
+        field :has_assignable_contacts, from: 'Has_Assignable_Contacts__c', as: :boolean
 
         self.table_name = 'Account'
       end

--- a/lib/openstax/salesforce/version.rb
+++ b/lib/openstax/salesforce/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Salesforce
-    VERSION = '8.0.0'
+    VERSION = '8.1.0'
   end
 end


### PR DESCRIPTION
For [DATA-133](https://openstax.atlassian.net/browse/DATA-133)
This adds a field so we can show messaging/prompts to a user who is at a school that has Assignable, but they have not integrated with it yet.

[DATA-133]: https://openstax.atlassian.net/browse/DATA-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ