### PR TITLE
Add expected_start_semester field to Lead

### DIFF
--- a/lib/openstax/salesforce/remote/lead.rb
+++ b/lib/openstax/salesforce/remote/lead.rb
@@ -42,6 +42,7 @@ module OpenStax
         field :signup_date,         from: 'Signup_Date__c', as: :datetime
         field :self_reported_school, from: 'Self_Reported_School__c'
         field :tracking_parameters,  from: 'Tracking_Parameters__c'
+        field :expected_start_semester, from: 'Expected_Start_Semester__c'
 
         # These 2 fields both hold the Account (School) ID, but have different data types and uses in SF
         field :account_id,          from: 'Account_ID__c'

--- a/lib/openstax/salesforce/version.rb
+++ b/lib/openstax/salesforce/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Salesforce
-    VERSION = '8.2.0'
+    VERSION = '8.3.0'
   end
 end


### PR DESCRIPTION
## Summary
- Adds `expected_start_semester` field on `Lead` mapped to the `Expected_Start_Semester__c` Salesforce field
- Bumps gem version 8.2.0 → 8.3.0

## Context
The accounts app currently patches this field onto `OpenStax::Salesforce::Remote::Lead` in an initializer (see openstax/accounts data-301-expected-start-semester branch). Adding it here lets accounts drop the patch.

## Test plan
- [ ] CI green
- [ ] After merge & publish, `bundle update openstax_salesforce` in accounts brings in 8.3.0 and `lead.expected_start_semester=` works without the initializer monkeypatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)